### PR TITLE
Add section for JavaScript Event "widgetLoaded"

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,5 +236,5 @@ A JavaScript Event of "widgetLoaded" will be fired when your widget has been loa
 ```javascript
 window.addEventListener('widgetLoaded', function(event) {
   console.log('|||===> widgetLoaded Event Fired for: ' + event.detail.widgetId);
-}
+});
 ```

--- a/README.md
+++ b/README.md
@@ -228,3 +228,13 @@ const mpHost = 'mpi.ministryplatform.com';
 ```
 
 You must change this to be your MP host.  After that simple include this javascript on any page you want to force login.
+
+## JavaScript Events
+
+A JavaScript Event of "widgetLoaded" will be fired when your widget has been loaded.
+
+```javascript
+window.addEventListener('widgetLoaded', function(event) {
+  console.log('|||===> widgetLoaded Event Fired for: ' + event.detail.widgetId);
+}
+```

--- a/Widgets/MyWeek/demo.html
+++ b/Widgets/MyWeek/demo.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-    <!-- Use this version for standalone web pages -->
+    <!-- Use this version to require user authentication -->
     <div
         id="MyWeekWidget"
         data-component="CustomWidget"
@@ -32,7 +32,7 @@
         data-params="@UserGUID=[UG]"
         data-template="MyWeek-template.html"
         data-requireUser="false"
-        data-cache="false"
+        data-cache="true"
         data-debug="false"
         data-host="[Your_Host_Name]"
     ></div>


### PR DESCRIPTION
Adds a blurb to the main README regarding the "widgetLoaded" JavaScript Event that is fired when the widget has finished loading. This was shown/discussed by Chris during the November Innovation Hour meeting and is very useful for anyone who needs additional JavaScript to run after the widget has been loaded.